### PR TITLE
Resurrect docker-dogstatsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM debian:wheezy
+FROM debian:jessie
 
 MAINTAINER Datadog <package@datadoghq.com>
 
 ENV DOCKER_DD_AGENT yes
-ENV AGENT_VERSION 1:5.1.1-546
+ENV AGENT_VERSION 1:5.8.0-1
 
 # Install the Agent
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
  && apt-get update \
- && apt-get install -y datadog-agent="${AGENT_VERSION}"
+ && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Configure the Agent
 # 1. Listen to statsd from other containers
@@ -23,5 +25,13 @@ COPY entrypoint.sh /entrypoint.sh
 # Expose DogStatsD port
 EXPOSE 8125/udp
 
+# Set proper permissions to allow running as a non-root user
+RUN chmod g+w /etc/dd-agent/datadog.conf
+RUN chmod -R g+w /var/log/datadog
+RUN chmod g+w /etc/dd-agent
+
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["dogstatsd"]
+
+USER 1001
+
+CMD /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/dogstatsd.py

--- a/README.md
+++ b/README.md
@@ -2,23 +2,21 @@
 
 This repository is meant to build the image for a DogStatsD container.
 
-**This image is deprecated. Please run [DogStatsD from docker-dd-agent](https://github.com/DataDog/docker-dd-agent#standalone-dogstatsd) instead.**
-
 ## Quick Start
 
-This image is ready-to-go, you just need to set your hostname and API_KEY in the environment.
+This image is ready-to-go, you just need to set your hostname and `API_KEY` in the environment.
 
 ```
-docker run -d --name dogstatsd -h `hostname` -e API_KEY=apikey_3 datadog/docker-dogstatsd
+docker run -d --name dogstatsd -h `hostname` -e API_KEY=YOUR_API_KEY datadog/docker-dogstatsd
 ```
 
 ## Link to other containers
 
-Your other containers will probably want to send datas to the DogStatsD container. For that, you will need to add a `--link` option to your run command.
+Your other containers will probably want to send data to the DogStatsD container. For that, you will need to add a `--link` option to your run command.
 
 ```
-docker run  --name my_container           \
-            --all_your_flags              \
+docker run  --name my_container \
+            --all_your_flags \
             --link dogstatsd:dogstatsd \
             my_image_id
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 #set -e
 
-if [[ $API_KEY ]]; then
-    sed -i -e "s/^.*api_key:.*$/api_key: ${API_KEY}/" /etc/dd-agent/datadog.conf
-else
-    echo "You must set API_KEY environment variable to run the DogStatsD container"
-    exit 1
+if [[ $DD_API_KEY ]]; then
+  export API_KEY=${DD_API_KEY}
 fi
 
-if [[ $TAGS ]]; then
-    sed -i -e "s/^#tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
+if [[ $API_KEY ]]; then
+	sed -i -e "s/^.*api_key:.*$/api_key: ${API_KEY}/" /etc/dd-agent/datadog.conf
+else
+	echo "You must set API_KEY environment variable to run the DogStatsD container"
+	exit 1
+fi
+
+if [[ $DD_URL ]]; then
+    sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /etc/dd-agent/datadog.conf
 fi
 
 export PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH"


### PR DESCRIPTION
# Why

To make it possible to run a dogstatsd server container with a non-root user.

# What

This PR un-deprecates the docker-dogstatsd image and upgrades the image to agent version `5.8` on Debian Jessie. It also runs the server as user id 1001 (we don't use a username because it doesn't guarantee that the user is not root so some platforms don't allow it).

# Related issues:
- https://github.com/DataDog/docker-dd-agent/issues/79